### PR TITLE
Update for BTD6 v56, and fix Upgrade Queueing swallowing the click when Shift-upgrading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updated for BTD6 v56
 - Upgrade Queueing can no longer purchase upgrades the player hasn't unlocked with XP yet
 - Fixed Upgrade Queueing silently ignoring the click when Shift upgrading a tower with an upgrade that can't be bought
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Upgrade Queueing can no longer purchase upgrades the player hasn't unlocked with XP yet
+- Fixed Upgrade Queueing silently ignoring the click when Shift upgrading a tower with an upgrade that can't be bought
 
 ## [1.4.7] - 2026-06-03
 

--- a/ModHelperData.cs
+++ b/ModHelperData.cs
@@ -2,8 +2,8 @@ namespace UsefulUtilities;
 
 public static class ModHelperData
 {
-    public const string WorksOnVersion = "55.0";
-    public const string Version = "1.4.7";
+    public const string WorksOnVersion = "56.0";
+    public const string Version = "1.4.8";
     public const string Name = "Useful Utilities";
 
     public const string Description =

--- a/Utilities/AutoNudge.cs
+++ b/Utilities/AutoNudge.cs
@@ -125,8 +125,8 @@ public class AutoNudgeUtility
         var bridge = InGame.instance.bridge;
         var cursorWorld = InGame.instance.GetWorldFromPointer(realCursorPos);
 
-        return bridge.CanPlaceTowerAt(cursorWorld, inputManager.placementModel, bridge.MyPlayerNumber,
-            inputManager.placementEntityId);
+        return bridge.CanPlaceTowerAt(cursorWorld, inputManager.placementModel,
+            inputManager.PlayerContext.playerIndex, inputManager.placementEntityId);
     }
 
     private static void NudgeDirection(Vector2 dir)

--- a/Utilities/InGameHeroSwitch.cs
+++ b/Utilities/InGameHeroSwitch.cs
@@ -60,10 +60,13 @@ public class InGameHeroSwitchUtility
         }
     }
 
+    // v56 removed UnityToSimulation.MyPlayerNumber, player numbers now come from the PlayerContext
+    private static int MyPlayerNumber => InGame.instance.PlayerOne.playerIndex;
+
     private static string CurrentHero
     {
-        get => InGame.Bridge.players[InGame.Bridge.MyPlayerNumber].hero;
-        set => InGame.Bridge.players[InGame.Bridge.MyPlayerNumber].hero = value;
+        get => InGame.Bridge.players[MyPlayerNumber].hero;
+        set => InGame.Bridge.players[MyPlayerNumber].hero = value;
     }
 
     private static void ChangeHero(int delta)

--- a/Utilities/QuickSell.cs
+++ b/Utilities/QuickSell.cs
@@ -35,7 +35,7 @@ public class QuickSell : ToggleableUtility
 
             if (!InGame.instance.hotkeys.sell.isPressed || !GetInstance<QuickSell>().Enabled) return true;
 
-            InGame.instance.SellTower(tower);
+            InGame.instance.SellTower(tower.owner, tower);
             return false;
         }
     }

--- a/Utilities/SandboxRoundEnd.cs
+++ b/Utilities/SandboxRoundEnd.cs
@@ -45,7 +45,10 @@ public class SandboxRoundEnd : ToggleableUtility
             if (!__instance.sandbox) return true;
 
             __instance.DistributeXp(round);
-            __instance.factory.GetUncast<Tower>().ForEach(tower => tower.OnRoundComplete(round));
+            foreach (var tower in __instance.factory.GetUncast<Tower>())
+            {
+                tower.OnRoundComplete(round);
+            }
             __instance.OnRoundEndProjectiles();
 
             BridgeMessaging<BridgeMessagingDelegates.OnEarlyRoundEnd>.Trigger?.Invoke(round);

--- a/Utilities/UnFastForwardOnDanger.cs
+++ b/Utilities/UnFastForwardOnDanger.cs
@@ -48,7 +48,7 @@ public class UnFastForwardOnDanger : ToggleableUtility
             if (cooldown > 0) return;
             cooldown = 0;
 
-            __instance.factory.GetUncast<Bloon>().ForEach(bloon =>
+            foreach (var bloon in __instance.factory.GetUncast<Bloon>())
             {
                 if (!bloon.bloonModel.isBoss &&
                     bloon.PercThroughMap() >= TrackThreshold / 100f &&
@@ -57,7 +57,7 @@ public class UnFastForwardOnDanger : ToggleableUtility
                     TimeManager.FastForwardActive = false;
                     cooldown = 180;
                 }
-            });
+            }
         }
     }
 }

--- a/Utilities/UpgradeQueueing.cs
+++ b/Utilities/UpgradeQueueing.cs
@@ -236,11 +236,12 @@ public class UpgradeQueueing : UsefulUtility
 
             if (upgrade == null) return !shift;
 
-            if (!__instance.Bridge.IsUpgradeLocked(tower.Id, index, tier) && InGame.instance.Player.HasUpgrade(upgrade))
-            {
-                EnqueueUpgrade(new QueuedUpgrade(tower.Id, index, tier, upgrade));
-                delay = .1f;
-            }
+            // Let the base game handle upgrades that can't be bought, so that it still gives its own feedback
+            if (__instance.Bridge.IsUpgradeLocked(tower.Id, index, tier) ||
+                !InGame.instance.Player.HasUpgrade(upgrade)) return true;
+
+            EnqueueUpgrade(new QueuedUpgrade(tower.Id, index, tier, upgrade));
+            delay = .1f;
 
             return !shift;
         }

--- a/Utilities/UpgradeQueueing.cs
+++ b/Utilities/UpgradeQueueing.cs
@@ -151,14 +151,15 @@ public class UpgradeQueueing : UsefulUtility
                 ref cost))
         {
             processingUpgrade = true;
-            UnityToSimulation.Current.UpgradeTower(tower.Id, queuedUpgrade.Path, 0, new Action<bool>(success =>
-            {
-                if (success)
+            UnityToSimulation.Current.UpgradeTower(tower.PlayerOwnerId, tower.Id, queuedUpgrade.Path, 0,
+                new Action<bool>(success =>
                 {
-                    QueuedUpgrades.Remove(queuedUpgrade);
-                }
-                processingUpgrade = false;
-            }));
+                    if (success)
+                    {
+                        QueuedUpgrades.Remove(queuedUpgrade);
+                    }
+                    processingUpgrade = false;
+                }));
         }
     }
 


### PR DESCRIPTION
Two related-but-separable changes, one commit each — reviewable independently.

## `2bffef2` — Upgrade Queueing silently ignores the click when Shift-upgrading

When Shift-upgrading a tower whose next upgrade couldn't be bought (locked by the round/tier restriction, or not yet unlocked with XP), the patch fell through to `return !shift`. With Shift held that returns `false`, which suppresses the base game's handler entirely — so the click did nothing at all: no popup, no sound, no indication of why.

The guard now returns `true` for those cases and lets the base game handle the click, so it gives its normal "can't buy this" feedback. Only upgrades that actually pass the check get enqueued.

## `e72894d` — Update for BTD6 v56

Version bump to `WorksOnVersion = "56.0"` / `Version = "1.4.8"`, plus the signature changes v56 introduced:

- **Player number is now carried by `PlayerContext`.** `UnityToSimulation.MyPlayerNumber` is gone. `InGameHeroSwitch` reads `InGame.instance.PlayerOne.playerIndex` via a small `MyPlayerNumber` helper; `AutoNudge` passes `inputManager.PlayerContext.playerIndex` to `CanPlaceTowerAt`.
- **Player-owner arguments added.** `UnityToSimulation.UpgradeTower` now takes `tower.PlayerOwnerId` as its first argument, and `InGame.instance.SellTower` takes `tower.owner`.
- **`.ForEach` on `factory.GetUncast<T>()` replaced with `foreach`** in `SandboxRoundEnd` and `UnFastForwardOnDanger`.

Behavior is otherwise unchanged in that commit — it's purely keeping up with the API.
